### PR TITLE
Override farbgeber with event-specific colors

### DIFF
--- a/components/DetectCryptoParty.py
+++ b/components/DetectCryptoParty.py
@@ -28,7 +28,7 @@ class DetectCryptoParty(msgflo.Participant):
     d = {
       'component': 'c-flo/DetectCryptoParty',
       'label': 'Detect a CryptoParty event',
-      'icon': 'star-o',
+      'icon': 'unlock-alt ',
       'inports': [
         { 'id': 'current', 'type': 'array'}
       ],

--- a/components/DetectCryptoParty.py
+++ b/components/DetectCryptoParty.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+import gevent
+import msgflo
+
+def hasCryptoParty(events):
+    for event in events:
+        if event['summary'].lower() == 'cryptoparty':
+            return True
+    return False
+
+#CryptoParty colors: purple(217/0/255 | d900ff) && pink(255/0/152 | ff0098)
+cryptoPartyPurple = [217, 0, 255]
+cryptoPartyPink   = [255, 0, 152]
+
+def getColorsForDmx():
+    return {
+      'b': cryptoPartyPink, # base color, usually not utilized
+      'c': cryptoPartyPurple, # columns
+      'v1': cryptoPartyPink, # ceiling1
+      'v2': cryptoPartyPink, # ceiling2
+      'v3': cryptoPartyPurple, # wall? in `dmx` wall is randomly chosen from v1-v4
+      'v4': cryptoPartyPurple, # gate
+    }
+
+
+class DetectCryptoParty(msgflo.Participant):
+  def __init__(self, role):
+    d = {
+      'component': 'c-flo/DetectCryptoParty',
+      'label': 'Detect a CryptoParty event',
+      'icon': 'star-o',
+      'inports': [
+        { 'id': 'current', 'type': 'array'}
+      ],
+      'outports': [
+        { 'id': 'palette', 'type': 'object' },
+      ],
+    }
+    msgflo.Participant.__init__(self, d, role)
+
+  def process(self, inport, msg):
+    if len(msg.data) and hasCryptoParty(msg.data):
+      self.send('palette', getColorsForDmx())
+    self.ack(msg)
+
+if __name__ == '__main__':
+  msgflo.main(DetectCryptoParty)

--- a/components/EventColors.py
+++ b/components/EventColors.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-import gevent
 import msgflo
 
 def getCryptoParty(palette):
@@ -16,6 +15,9 @@ def getCryptoParty(palette):
   }
 
 def handleEvents(events, palette):
+  if len(events) == 0:
+    # farbgeber when there are no events
+    return palette
   for event in events:
     if event['summary'].lower() == 'cryptoparty':
       return getCryptoParty(palette)
@@ -30,7 +32,7 @@ class EventColors(msgflo.Participant):
       'icon': 'palette',
       'inports': [
         { 'id': 'current', 'type': 'array'},
-        { 'id': 'palette', 'type': 'object' },
+        { 'id': 'colors', 'type': 'object' },
       ],
       'outports': [
         { 'id': 'palette', 'type': 'object' },
@@ -47,11 +49,10 @@ class EventColors(msgflo.Participant):
         self.send('palette', handleEvents(msg.data, self.palette))
       self.ack(msg)
       return
-    if inport == 'palette':
+    if inport == 'colors':
       self.palette = msg.data
-      self.send('palette', handleEvents(msg.current_events, msg.data))
-      self.ack(msg)
-      return
+      self.send('palette', handleEvents(self.current_events, msg.data))
+    self.ack(msg)
 
 if __name__ == '__main__':
   msgflo.main(EventColors)

--- a/components/EventColors.py
+++ b/components/EventColors.py
@@ -3,24 +3,24 @@ import gevent
 import msgflo
 
 def hasCryptoParty(events):
-    for event in events:
-        if event['summary'].lower() == 'cryptoparty':
-            return True
-    return False
+  for event in events:
+    if event['summary'].lower() == 'cryptoparty':
+      return True
+  return False
 
 #CryptoParty colors: purple(217/0/255 | d900ff) && pink(255/0/152 | ff0098)
 cryptoPartyPurple = [217, 0, 255]
 cryptoPartyPink   = [255, 0, 152]
 
 def getColorsForDmx():
-    return {
-      'b': cryptoPartyPink, # base color, usually not utilized
-      'c': cryptoPartyPurple, # columns
-      'v1': cryptoPartyPink, # ceiling1
-      'v2': cryptoPartyPink, # ceiling2
-      'v3': cryptoPartyPurple, # wall? in `dmx` wall is randomly chosen from v1-v4
-      'v4': cryptoPartyPurple, # gate
-    }
+  return {
+    'b': cryptoPartyPink, # base color, usually not utilized
+    'c': cryptoPartyPurple, # columns
+    'v1': cryptoPartyPink, # ceiling1
+    'v2': cryptoPartyPink, # ceiling2
+    'v3': cryptoPartyPurple, # wall? in `dmx` wall is randomly chosen from v1-v4
+    'v4': cryptoPartyPurple, # gate
+  }
 
 
 class DetectCryptoParty(msgflo.Participant):

--- a/components/EventColors.py
+++ b/components/EventColors.py
@@ -2,17 +2,10 @@
 import gevent
 import msgflo
 
-def hasCryptoParty(events):
-  for event in events:
-    if event['summary'].lower() == 'cryptoparty':
-      return True
-  return False
-
-#CryptoParty colors: purple(217/0/255 | d900ff) && pink(255/0/152 | ff0098)
-cryptoPartyPurple = [217, 0, 255]
-cryptoPartyPink   = [255, 0, 152]
-
-def getColorsForDmx():
+def getCryptoParty(palette):
+  #CryptoParty colors: purple(217/0/255 | d900ff) && pink(255/0/152 | ff0098)
+  cryptoPartyPurple = [217, 0, 255]
+  cryptoPartyPink   = [255, 0, 152]
   return {
     'b': cryptoPartyPink, # base color, usually not utilized
     'c': cryptoPartyPurple, # columns
@@ -22,26 +15,43 @@ def getColorsForDmx():
     'v4': cryptoPartyPurple, # gate
   }
 
+def handleEvents(events, palette):
+  for event in events:
+    if event['summary'].lower() == 'cryptoparty':
+      return getCryptoParty(palette)
+  # Default to farbgeber
+  return palette
 
-class DetectCryptoParty(msgflo.Participant):
+class EventColors(msgflo.Participant):
   def __init__(self, role):
     d = {
-      'component': 'c-flo/DetectCryptoParty',
-      'label': 'Detect a CryptoParty event',
-      'icon': 'unlock-alt ',
+      'component': 'c-flo/EventColors',
+      'label': 'Produce color schemes for events',
+      'icon': 'palette',
       'inports': [
-        { 'id': 'current', 'type': 'array'}
+        { 'id': 'current', 'type': 'array'},
+        { 'id': 'palette', 'type': 'object' },
       ],
       'outports': [
         { 'id': 'palette', 'type': 'object' },
       ],
     }
+    self.palette = None
+    self.current_events = []
     msgflo.Participant.__init__(self, d, role)
 
   def process(self, inport, msg):
-    if len(msg.data) and hasCryptoParty(msg.data):
-      self.send('palette', getColorsForDmx())
-    self.ack(msg)
+    if inport == 'current':
+      self.current_events = msg.data
+      if self.palette:
+        self.send('palette', handleEvents(msg.data, self.palette))
+      self.ack(msg)
+      return
+    if inport == 'palette':
+      self.palette = msg.data
+      self.send('palette', handleEvents(msg.current_events, msg.data))
+      self.ack(msg)
+      return
 
 if __name__ == '__main__':
-  msgflo.main(DetectCryptoParty)
+  msgflo.main(EventColors)

--- a/graphs/main.json
+++ b/graphs/main.json
@@ -817,7 +817,7 @@
       },
       "tgt": {
         "process": "eventcolors",
-        "port": "palette"
+        "port": "colors"
       }
     },
     {

--- a/graphs/main.json
+++ b/graphs/main.json
@@ -782,7 +782,7 @@
     },
     {
       "src": {
-        "process": "farbgeber",
+        "process": "eventcolors",
         "port": "palette"
       },
       "tgt": {

--- a/graphs/main.json
+++ b/graphs/main.json
@@ -117,6 +117,9 @@
     "echelon": {
       "component": "c-flo/echelon"
     },
+    "eventcolors": {
+      "component": "c-flo/EventColors"
+    },
     "farbdmx": {
       "component": "c-flo/farbdmx"
     },
@@ -479,6 +482,16 @@
     },
     {
       "src": {
+        "process": "EventCalendar",
+        "port": "current"
+      },
+      "tgt": {
+        "process": "eventcolors",
+        "port": "current"
+      }
+    },
+    {
+      "src": {
         "process": "togglelights",
         "port": "out"
       },
@@ -800,6 +813,16 @@
     {
       "src": {
         "process": "farbgeber",
+        "port": "palette"
+      },
+      "tgt": {
+        "process": "eventcolors",
+        "port": "palette"
+      }
+    },
+    {
+      "src": {
+        "process": "eventcolors",
         "port": "palette"
       },
       "tgt": {

--- a/spec/EventColors.yaml
+++ b/spec/EventColors.yaml
@@ -1,0 +1,41 @@
+name: 'Handling event colors'
+topic: c-flo/EventColors
+fixture:
+  type: 'fbp'
+  data: |
+    INPORT=eventcolors.CURRENT:CURRENT
+    INPORT=eventcolors.PALETTE:PALETTE
+    OUTPORT=eventcolors.PALETTE:PALETTE
+    eventcolors(c-flo/EventColors)
+cases:
+-
+  name: 'when there is no event'
+  assertion: 'should return farbgeber palette'
+  inputs:
+    current: []
+    palette:
+      b: [0, 0, 0]
+  expect:
+    palette:
+      -
+        equals:
+          b: [0, 0, 0]
+-
+  name: 'when there is a cryptoparty'
+  assertion: 'should return cryptoparty pink'
+  inputs:
+    current:
+      -
+        summary: cryptoparty
+    palette:
+      b: [0, 0, 0]
+  expect:
+    palette:
+      -
+        equals:
+          b: [217, 0, 255]
+          c: [255, 0, 152]
+          v1: [217, 0, 255]
+          v2: [217, 0, 255]
+          v3: [255, 0, 152]
+          v4: [255, 0, 152]

--- a/spec/EventColors.yaml
+++ b/spec/EventColors.yaml
@@ -3,17 +3,17 @@ topic: c-flo/EventColors
 fixture:
   type: 'fbp'
   data: |
-    INPORT=eventcolors.CURRENT:CURRENT
-    INPORT=eventcolors.PALETTE:PALETTE
-    OUTPORT=eventcolors.PALETTE:PALETTE
-    eventcolors(c-flo/EventColors)
+    INPORT=Events.CURRENT:CURRENT
+    INPORT=Events.COLORS:COLORS
+    OUTPORT=Events.PALETTE:PALETTE
+    Events(c-flo/EventColors)
 cases:
 -
   name: 'when there is no event'
   assertion: 'should return farbgeber palette'
   inputs:
     current: []
-    palette:
+    colors:
       b: [0, 0, 0]
   expect:
     palette:
@@ -27,15 +27,15 @@ cases:
     current:
       -
         summary: cryptoparty
-    palette:
+    colors:
       b: [0, 0, 0]
   expect:
     palette:
       -
         equals:
-          b: [217, 0, 255]
-          c: [255, 0, 152]
-          v1: [217, 0, 255]
-          v2: [217, 0, 255]
-          v3: [255, 0, 152]
-          v4: [255, 0, 152]
+          b: [255, 0, 152]
+          c: [217, 0, 255]
+          v1: [255, 0, 152]
+          v2: [255, 0, 152]
+          v3: [217, 0, 255]
+          v4: [217, 0, 255]


### PR DESCRIPTION
This allows event organizers to have their color schemes applied to the mainhall automatically.

Fixes #109
See also #45